### PR TITLE
Dev/cbj0730

### DIFF
--- a/bookoo_mini_scale/protocols.md
+++ b/bookoo_mini_scale/protocols.md
@@ -36,10 +36,10 @@ if CheckSum == DataSUM
 | 03 | 0A | 01 | 00 | 00 | 08 | Send the tare command |
 | 03 | 0A | 02 | 00 | 00~05 (Beep level) | checkSum | Adjust the beep size, 0 means no beeper sound on |
 | 03 | 0A | 03 | 00 | 05~1e (Auto-off duration) | checkSum | Adjust the automatic shutdown duration from 5-30 minutes |
-| 03 | 0A | 04 | 00 | 00 | 0a | Send the start timer command |
-| 03 | 0A | 05 | 00 | 00 | 0d | Send the stop timer command |
-| 03 | 0A | 06 | 00 | 00 | 0c | Send the reset timer command |
-| 03 | 0A | 07 | 00 | 00 | 00 | Send the tare and start time command (recommend) |
+| 03 | 0A | 04 | 00 | 00 | 0d | Send the start timer command |
+| 03 | 0A | 05 | 00 | 00 | 0c | Send the stop timer command |
+| 03 | 0A | 06 | 00 | 00 | 0f | Send the reset timer command |
+| 03 | 0A | 07 | 00 | 00 | 0e | Send the tare and start time command (recommend) |
 | 03 | 0A | 08 | 00/01 | 00 | checkSum | Whether or not flow smoothing is turned on, 00 means it is not turned on, 01 means it is turned on |
 
 ### Receiving Weight
@@ -49,7 +49,7 @@ if CheckSum == DataSUM
 | BYTE1 | BYTE2 | BYTE3 | BYTE4 | BYTE5 | BYTE6 | BYTE7 |BYTE8 |BYTE9 |BYTE10 |BYTE11 |BYTE12 |BYTE13 |BYTE14 |BYTE15 |BYTE16 |BYTE17 |BYTE18 |BYTE19 |BYTE20 |DESCRIPTION |
 | ----------- | ----------- |----------- |----------- |----------- |----------- |----------- |----------- |----------- |----------- |----------- |----------- |----------- |----------- |----------- |----------- |----------- |----------- |----------- |----------- |----------- |
 | PRODUCT NUMBER | TYPE | DATA1 | DATA2 | DATA3 |  DATA4 | DATA5 | DATA6 | DATA7 | DATA8 | DATA9 | DATA10 | DATA11 | DATA12 | DATA13 | DATA14 | DATA15 | DATA16 | DATA17 | DATASUM |DESCRIPTION |
-| 03 | 0B | <br>MillSeconds <br><br><br> High byte of a unsigned Short integer	|MillSeconds <br><br><br> Mid byte of a unsigned Short integer |MillSeconds <br><br><br> Low byte of a unsigned Short integer | unit of weight |Weight symbol data points (+/-)|<br>Grams weight * 100 <br><br><br> High byte of a unsigned Short integer |<br>Grams weight * 100 <br><br><br> Mid byte of a unsigned Short integer |<br>Grams weight * 100 <br><br><br> Low byte of a unsigned Short integer |Flow rate symbol data points (+/-)|Flow rate*100 <br><br><br> High byte of a unsigned Short integer|Flow rate*100 <br><br><br> Low byte of a unsigned Short integer|Percentage of remaining power | standby time (min) <br><br><br> High byte of a unsigned Short integer |standby time (min) <br><br><br> Low byte of a unsigned Short integer| Buzzer gear | Flow Rate Smoothing Switch |00 |00 | Get time, weight, flow rate and power percentage data on the scale |
+| 03 | 0B | <br>MillSeconds <br><br><br> High byte of an unsigned 24-bit integer |MillSeconds <br><br><br> Mid byte of an unsigned 24-bit integer |MillSeconds <br><br><br> Low byte of an unsigned 24-bit integer | unit of weight |Weight symbol data points (+/-)|<br>Grams weight * 100 <br><br><br> High byte of an unsigned 24-bit integer |<br>Grams weight * 100 <br><br><br> Mid byte of an unsigned 24-bit integer |<br>Grams weight * 100 <br><br><br> Low byte of an unsigned 24-bit integer |Flow rate symbol data points (+/-)|Flow rate*100 <br><br><br> High byte of an unsigned Short integer|Flow rate*100 <br><br><br> Low byte of an unsigned Short integer|Percentage of remaining power | standby time (min * 10) <br><br><br> High byte of an unsigned Short integer |standby time (min * 10) <br><br><br> Low byte of an unsigned Short integer| Buzzer gear | Flow Rate Smoothing Switch |Reserved |checkSum | Get time, weight, flow rate and power percentage data on the scale |
 
 ### Other Data
 

--- a/bookoo_ultra_scale/protocols.md
+++ b/bookoo_ultra_scale/protocols.md
@@ -36,13 +36,14 @@ if CheckSum == DataSUM
 | 03 | 0A | 01 | 00 | 00 | 08 | Send the tare command | Not valid during automatic mode operation. |
 | 03 | 0A | 02 | 00 | 00~05 (Beep level) | checkSum | Adjust the beep size, 0 means no beeper sound on | |
 | 03 | 0A | 03 | 00 | 05~1e (Auto-off duration) | checkSum | Adjust the automatic shutdown duration from 5-30 minutes | |
-| 03 | 0A | 04 | 00 | 00 | 0a | Send the start timer command | Only effective in timing-mode and ratio-mode. |
-| 03 | 0A | 05 | 00 | 00 | 0d | Send the stop timer command | Only effective in timing-mode and ratio-mode. |
-| 03 | 0A | 06 | 00 | 00 | 0c | Send the reset timer command | Only effective in timing-mode and ratio-mode. |
-| 03 | 0A | 07 | 00 | 00 | 00 | Send the tare and start time command (recommend) |  |
+| 03 | 0A | 04 | 00 | 00 | 0d | Send the start timer command | Only effective in timing-mode and ratio-mode. |
+| 03 | 0A | 05 | 00 | 00 | 0c | Send the stop timer command | Only effective in timing-mode and ratio-mode. |
+| 03 | 0A | 06 | 00 | 00 | 0f | Send the reset timer command | Only effective in timing-mode and ratio-mode. |
+| 03 | 0A | 07 | 00 | 00 | 0e | Send the tare and start time command (recommend) |  |
 | 03 | 0A | 08 | 00/01 | 00 | checkSum | Whether or not flow smoothing is turned on, 00 means it is not turned on, 01 means it is turned on | |
 | 03 | 0A | 09 | 00 | 00 | 00 | Send the calibration command. | Only effective in weight-mode |
 | 03 | 0A | 0B | 00/01 | 00 | checkSum | Set the stop condition for automatic-mode, 00 means that the stop condition is the liquid flow stopping, and 01 means that the stop condition is the container being removed. | |
+| 03 | 0A | 0D | Powder weight * 10<br>High byte | Powder weight * 10<br>Low byte | checkSum | Set the powder weight | Unit: gram, valid range: 0.1-999.0 g |
 
 
 ### Receiving Weight
@@ -52,7 +53,16 @@ if CheckSum == DataSUM
 | BYTE1 | BYTE2 | BYTE3 | BYTE4 | BYTE5 | BYTE6 | BYTE7 |BYTE8 |BYTE9 |BYTE10 |BYTE11 |BYTE12 |BYTE13 |BYTE14 |BYTE15 |BYTE16 |BYTE17 |BYTE18 |BYTE19 |BYTE20 |DESCRIPTION |
 | ----------- | ----------- |----------- |----------- |----------- |----------- |----------- |----------- |----------- |----------- |----------- |----------- |----------- |----------- |----------- |----------- |----------- |----------- |----------- |----------- |----------- |
 | PRODUCT NUMBER | TYPE | DATA1 | DATA2 | DATA3 |  DATA4 | DATA5 | DATA6 | DATA7 | DATA8 | DATA9 | DATA10 | DATA11 | DATA12 | DATA13 | DATA14 | DATA15 | DATA16 | DATA17 | DATASUM |DESCRIPTION |
-| 03 | 0B | <br>MillSeconds <br><br><br> High byte of a unsigned Short integer	|MillSeconds <br><br><br> Mid byte of a unsigned Short integer |MillSeconds <br><br><br> Low byte of a unsigned Short integer | unit of weight <br><br>01:Ounce<br>02:Gram |Weight symbol data points (+/-)|<br>Grams weight * 100 <br><br><br> High byte of a unsigned Short integer |<br>Grams weight * 100 <br><br><br> Mid byte of a unsigned Short integer |<br>Grams weight * 100 <br><br><br> Low byte of a unsigned Short integer |Flow rate symbol data points (+/-)|Flow rate*100 <br><br><br> High byte of a unsigned Short integer|Flow rate*100 <br><br><br> Low byte of a unsigned Short integer|Percentage of remaining power | standby time (min) <br><br><br> High byte of a unsigned Short integer |standby time (min) <br><br><br> Low byte of a unsigned Short integer| Buzzer gear | Flow Rate Smoothing Switch | Stop conditions for automatic-mode. |00 | Get time, weight, flow rate and power percentage data on the scale |
+| 03 | 0B | <br>MillSeconds <br><br><br> High byte of an unsigned 24-bit integer |MillSeconds <br><br><br> Mid byte of an unsigned 24-bit integer |MillSeconds <br><br><br> Low byte of an unsigned 24-bit integer | unit of weight <br><br>01:Gram<br>02:Ounce |Weight symbol data points (+/-)|<br>Grams weight * 100 <br><br><br> High byte of an unsigned 24-bit integer |<br>Grams weight * 100 <br><br><br> Mid byte of an unsigned 24-bit integer |<br>Grams weight * 100 <br><br><br> Low byte of an unsigned 24-bit integer |Flow rate symbol data points (+/-)|Flow rate*100 <br><br><br> High byte of an unsigned Short integer|Flow rate*100 <br><br><br> Low byte of an unsigned Short integer|Percentage of remaining power | standby time (min * 10) <br><br><br> High byte of an unsigned Short integer |standby time (min * 10) <br><br><br> Low byte of an unsigned Short integer| Buzzer gear | Flow Rate Smoothing Switch |00 |checkSum | Get time, weight, flow rate and power percentage data on the scale |
+
+### Receiving Powder Weight
+
+>Note: The powder weight unit is grams
+
+| BYTE1 | BYTE2 | BYTE3 | BYTE4 | BYTE5 | BYTE6 | BYTE7 |BYTE8 |BYTE9 |BYTE10 |BYTE11 |BYTE12 |BYTE13 |BYTE14 |BYTE15 |BYTE16 |BYTE17 |BYTE18 |BYTE19 |BYTE20 |DESCRIPTION |
+| ----------- | ----------- |----------- |----------- |----------- |----------- |----------- |----------- |----------- |----------- |----------- |----------- |----------- |----------- |----------- |----------- |----------- |----------- |----------- |----------- |----------- |
+| PRODUCT NUMBER | TYPE | DATA1 | DATA2 | DATA3 | DATA4 | DATA5 | DATA6 | DATA7 | DATA8 | DATA9 | DATA10 | DATA11 | DATA12 | DATA13 | DATA14 | DATA15 | DATA16 | DATA17 | DATASUM |DESCRIPTION |
+| 03 | 0F | Powder weight symbol data points (+/-) | Powder weight * 100<br>High byte of an unsigned 24-bit integer | Powder weight * 100<br>Mid byte of an unsigned 24-bit integer | Powder weight * 100<br>Low byte of an unsigned 24-bit integer |00 |00 |00 |00 |00 |00 |00 |00 |00 |00 |00 |00 |00 |checkSum | Get powder weight data on the scale |
 
 ### Other Data
 


### PR DESCRIPTION
大小秤开源协议做出以下调整修复
mini(V1.4.1版本基准)：1.修正计时命令XOR校验值
                                         2.修正待机时间/校验位等描述
ultra(V3.1.2版本基准) ：1.修正命令XOR校验值
                                   2.修正重量单位编码
                                   3.移除常规化广播BYTE19自动模式停止条件，设置为00
                                   4.开放粉重设置指令，新增粉重广播(首次进入比例模式、设置完新粉重数据时触发)